### PR TITLE
Fix rendering of fnumber

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -149,7 +149,7 @@ Ordinal: {{ .Ordinal}}
 						{{ end }}
 
 						{{ if $showExif }}
-							data-description="{{ .Model }}{{ if and .Model .LensModel }} + {{ end }}{{ .LensModel }}<br/>{{ if .FocalLength }}{{ .FocalLength }}mm {{ end }}{{ if .FNumber }}f/{{ .FNumber }} {{ end }}{{ if .ExposureTime }}{{ .ExposureTime }}sec {{ end }} {{ if .ISOSpeedRatings }}ISO {{ .ISOSpeedRatings }}{{ end }}"
+							data-description="{{ .Model }}{{ if and .Model .LensModel }} + {{ end }}{{ .LensModel }}<br/>{{ if .FocalLength }}{{ .FocalLength }}mm {{ end }}{{ if .FNumber }}f/{{ printf "%.1f" .FNumber.Float64 }} {{ end }}{{ if .ExposureTime }}{{ .ExposureTime }}sec {{ end }} {{ if .ISOSpeedRatings }}ISO {{ .ISOSpeedRatings }}{{ end }}"
 						{{ end }}
 
 						{{ if not (eq $filterOptions "[]")  }}


### PR DESCRIPTION
FNumber is represented as a imagemeta.rat[uint32], which contains a numerator and a denominator. If used directly in a template this results in fractional apertures (e.g. 5.6) in their rational form (e.g. 28/5) rather than as a float with one sig fig. 

This commit updates the EXIF rendering logic, casting the rational to a float64, and then rendering it with at most 1 sig fig.

Before:
<img width="388" alt="Screenshot 2024-08-09 at 8 35 27 PM" src="https://github.com/user-attachments/assets/775e6161-3f61-4882-9a27-2d32cc4ce94b">
After:
<img width="363" alt="Screenshot 2024-08-09 at 8 35 02 PM" src="https://github.com/user-attachments/assets/5be6cdd5-6bfd-4912-9d0b-696dd1078dc0">

I looked at example photos with both rational and integer apertures, and didn't see any issues, though this wasn't exhaustive.
